### PR TITLE
Design spike for an Oracle - v1

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,3 @@
+This is not production ready code! Do not use without my permission.
+
+Copyright (c) by Alexander Peters 2020

--- a/design/overview.md
+++ b/design/overview.md
@@ -43,6 +43,8 @@ Key concepts that we mention below will be defined here:
 * `Confirmed` - Many actions in Peggy require RLP encoded signatures to be submitted by the `Orchestrators`, an operation is `Confirmed` when it is possible to execute it on Ethereum by collecting and submitting these RLP encoded signatures representing 66% of all voting power encoded in the `Last Valset`.
 * `Observed` - events on Ethereum are considered `Observed` when 66% of the active Cosmos validator set during a given block has submitted an oracle message attesting to seeing the event. Note this is distinct from `Confirmed`! At any given time the set of who can `Observe` an event and who can `Confirm` and event will be slightly different. Since `Confirmed` is based off of the `Last ValSet` and `Observed` is always up to date with the latest validator set.
 
+* `Claim` - an Ethereum event signed and submitted to cosmos by a single `Orchestrator` instance 
+* `Attestation` - aggregate of claims that eventually becomes `observed` by all orchestrators
 
 The *Operator* is the key unit of trust here. Each operator is responsible for maintaining 3 secure processes:
 

--- a/module/x/peggy/alias.go
+++ b/module/x/peggy/alias.go
@@ -22,13 +22,18 @@ var (
 )
 
 type (
-	Keeper           = keeper.Keeper
-	MsgSetEthAddress = types.MsgSetEthAddress
-	MsgValsetConfirm = types.MsgValsetConfirm
-	MsgValsetRequest = types.MsgValsetRequest
-	MsgSendToEth     = types.MsgSendToEth
-	MsgRequestBatch  = types.MsgRequestBatch
-	MsgConfirmBatch  = types.MsgConfirmBatch
-	MsgBatchInChain  = types.MsgBatchInChain
-	MsgEthDeposit    = types.MsgEthDeposit
+	MsgSendToEth                       = types.MsgSendToEth
+	MsgRequestBatch                    = types.MsgRequestBatch
+	MsgConfirmBatch                    = types.MsgConfirmBatch
+	MsgBatchInChain                    = types.MsgBatchInChain
+	MsgEthDeposit                      = types.MsgEthDeposit
+	Keeper                             = keeper.Keeper
+	MsgSetEthAddress                   = types.MsgSetEthAddress
+	MsgValsetConfirm                   = types.MsgValsetConfirm
+	MsgValsetRequest                   = types.MsgValsetRequest
+	MsgCreateEthereumClaims            = types.MsgCreateEthereumClaims
+	EthereumClaim                      = types.EthereumClaim
+	EthereumBridgeDepositClaim         = types.EthereumBridgeDepositClaim
+	EthereumBridgeWithdrawalBatchClaim = types.EthereumBridgeWithdrawalBatchClaim
+	EthereumBridgeMultiSigUpdateClaim  = types.EthereumBridgeMultiSigUpdateClaim
 )

--- a/module/x/peggy/handler_test.go
+++ b/module/x/peggy/handler_test.go
@@ -1,0 +1,68 @@
+package peggy
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/althea-net/peggy/module/x/peggy/keeper"
+	"github.com/althea-net/peggy/module/x/peggy/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleCreateEthereumClaims(t *testing.T) {
+	var (
+		myOrchestratorAddr sdk.AccAddress = make([]byte, sdk.AddrLen)
+		myCosmosAddr       sdk.AccAddress = bytes.Repeat([]byte{1}, 12)
+		myValAddr                         = sdk.ValAddress(myOrchestratorAddr) // revisit when proper mapping is impl in keeper
+		myNonce                           = bytes.Repeat([]byte{2}, 12)
+		anyETHAddr                        = types.NewEthereumAddress("any-address")
+		myBlockTime                       = time.Date(2020, 9, 14, 15, 20, 10, 0, time.UTC)
+	)
+	k, ctx := keeper.CreateTestEnv(t)
+	k.StakingKeeper = keeper.NewStakingKeeperMock(myValAddr)
+	h := NewHandler(k)
+
+	msg := MsgCreateEthereumClaims{
+		EthereumChainID:       "0",
+		BridgeContractAddress: types.NewEthereumAddress(""),
+		Orchestrator:          myOrchestratorAddr,
+		Claims: []EthereumClaim{
+			EthereumBridgeDepositClaim{
+				Nonce:          myNonce,
+				ERC20Token:     types.ERC20Token{},
+				EthereumSender: anyETHAddr,
+				CosmosReceiver: myCosmosAddr,
+			},
+		},
+	}
+	// when
+	ctx = ctx.WithBlockTime(myBlockTime)
+	_, err := h(ctx, msg)
+	// then
+	require.NoError(t, err)
+	// and no
+	claimFound := k.HasClaim(ctx, types.ClaimTypeEthereumBridgeDeposit, myNonce, myValAddr)
+	assert.True(t, claimFound)
+	// and attestation persisted
+	a := k.GetAttestation(ctx, types.ClaimTypeEthereumBridgeDeposit, myNonce)
+	require.NotNil(t, a)
+	exp := types.Attestation{
+		ClaimType:     types.ClaimTypeEthereumBridgeDeposit,
+		Nonce:         myNonce,
+		Certainty:     types.CertaintyObserved,
+		Status:        types.ProcessStatusProcessed,
+		ProcessResult: types.ProcessResultSuccess,
+		Tally: types.AttestationTally{
+			TotalVotesPower:    100,
+			TotalVotesCount:    1,
+			RequiredVotesPower: 66,
+			RequiredVotesCount: 0,
+		},
+		SubmitTime:          myBlockTime,
+		ConfirmationEndTime: time.Date(2020, 9, 14+1, 15, 20, 10, 0, time.UTC),
+	}
+	assert.Equal(t, exp, *a)
+}

--- a/module/x/peggy/keeper/attestation_handler.go
+++ b/module/x/peggy/keeper/attestation_handler.go
@@ -1,0 +1,25 @@
+package keeper
+
+import (
+	"github.com/althea-net/peggy/module/x/peggy/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type AttestationHandler struct {
+	keeper Keeper
+}
+
+func (a AttestationHandler) Handle(ctx sdk.Context, att types.Attestation) error {
+	switch att.ClaimType {
+	case types.ClaimTypeEthereumBridgeDeposit:
+		// todo: mint new vouchers
+	case types.ClaimTypeEthereumBridgeWithdrawalBatch:
+		// todo: mark batch as successful
+	case types.ClaimTypeEthereumBridgeMultiSigUpdate:
+		// todo: update nonce for "MultiSig Set"
+	default:
+		return sdkerrors.Wrapf(types.ErrDuplicate, "event type: %X", att.ClaimType) // todo: claim type to string
+	}
+	return nil
+}

--- a/module/x/peggy/keeper/keeper.go
+++ b/module/x/peggy/keeper/keeper.go
@@ -15,15 +15,21 @@ type Keeper struct {
 	storeKey sdk.StoreKey // Unexposed key to access store from sdk.Context
 
 	cdc *codec.Codec // The wire codec for binary encoding/decoding.
+
+	AttestationHandler interface {
+		Handle(sdk.Context, types.Attestation) error
+	}
 }
 
 // NewKeeper creates new instances of the nameservice Keeper
 func NewKeeper(cdc *codec.Codec, storeKey sdk.StoreKey, stakingKeeper types.StakingKeeper) Keeper {
-	return Keeper{
+	k := Keeper{
 		cdc:           cdc,
 		storeKey:      storeKey,
 		StakingKeeper: stakingKeeper,
 	}
+	k.AttestationHandler = AttestationHandler{keeper: k}
+	return k
 }
 
 func (k Keeper) SetValsetRequest(ctx sdk.Context) {

--- a/module/x/peggy/keeper/oracle.go
+++ b/module/x/peggy/keeper/oracle.go
@@ -1,0 +1,133 @@
+package keeper
+
+import (
+	"fmt"
+
+	"github.com/althea-net/peggy/module/x/peggy/types"
+	"github.com/cosmos/cosmos-sdk/store/prefix"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+const (
+	EventTypeObservation        = "observation"
+	AttributeKeyAttestationType = "attestation_type"
+	AttributeKeyContract        = "bridge_contract"
+	AttributeKeyNonce           = "nonce"
+	AttributeKeyBridgeChainID   = "bridge_chain_id"
+)
+
+func (k Keeper) AddClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress) error {
+	if err := k.storeClaim(ctx, claimType, nonce, validator); err != nil {
+		return sdkerrors.Wrap(err, "claim")
+	}
+	validatorPower := k.StakingKeeper.GetLastValidatorPower(ctx, validator)
+	att, err := k.tryAttestation(ctx, claimType, nonce, uint64(validatorPower))
+	if err != nil {
+		return err
+	}
+	if att.Certainty != types.CertaintyObserved || att.Status != types.ProcessStatusInit {
+		return nil
+	}
+
+	// next process Attestation
+	xCtx, commit := ctx.CacheContext()
+
+	// end time was handled in adding claim and would return an error early
+	// no need to re-check here
+	if err := k.AttestationHandler.Handle(xCtx, *att); err != nil { // execute with a transient storage
+		// log
+		att.ProcessResult = types.ProcessResultFailure
+	} else {
+		att.ProcessResult = types.ProcessResultSuccess
+		commit() // persist transient storage
+	}
+	att.Status = types.ProcessStatusProcessed
+
+	// now store all updates
+	k.storeAttestation(ctx, att)
+
+	observationEvent := sdk.NewEvent(
+		EventTypeObservation, // todo: revisit types for clients
+		sdk.NewAttribute(sdk.AttributeKeyModule, types.ModuleName),
+		sdk.NewAttribute(AttributeKeyAttestationType, fmt.Sprintf("%X", att.ClaimType)), // todo: map to string
+		sdk.NewAttribute(AttributeKeyContract, types.BridgeContractAddress.String()),
+		sdk.NewAttribute(AttributeKeyBridgeChainID, types.BridgeContractChainID),
+		sdk.NewAttribute(AttributeKeyNonce, string(nonce)), // todo: serialize with hex/ base64 ?
+
+	)
+	ctx.EventManager().EmitEvent(observationEvent)
+	return nil
+}
+
+func (k Keeper) storeClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress) error {
+	store := ctx.KVStore(k.storeKey)
+	cKey := types.GetClaimKey(claimType, nonce, validator)
+	r := store.Get(cKey)
+	if r != nil {
+		return types.ErrDuplicate
+	}
+	store.Set(cKey, []byte{}) // empty as all payload is in the key already (no gas costs)
+	return nil
+}
+
+func (k Keeper) tryAttestation(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, power uint64) (*types.Attestation, error) {
+	now := ctx.BlockTime()
+	att := k.GetAttestation(ctx, claimType, nonce)
+	if att == nil {
+		count := len(k.StakingKeeper.GetBondedValidatorsByPower(ctx))
+		power := k.StakingKeeper.GetLastTotalPower(ctx)
+		att = &types.Attestation{
+			ClaimType:     claimType,
+			Nonce:         nonce,
+			Certainty:     types.CertaintyRequested,
+			Status:        types.ProcessStatusInit,
+			ProcessResult: types.ProcessResultUnknown,
+			Tally: types.AttestationTally{
+				RequiredVotesPower: types.AttestationVotesPowerThreshold.Mul(power.Uint64()),
+				RequiredVotesCount: types.AttestationVotesCountThreshold.Mul(uint64(count)),
+			},
+			SubmitTime:          now,
+			ConfirmationEndTime: now.Add(types.AttestationPeriod),
+		}
+	}
+	if err := att.AddConfirmation(now, power); err != nil {
+		return nil, err
+	}
+	return att, nil
+}
+
+func (k Keeper) storeAttestation(ctx sdk.Context, att *types.Attestation) {
+	aKey := types.GetAttestationKey(att.ClaimType, att.Nonce)
+	store := ctx.KVStore(k.storeKey)
+	store.Set(aKey, k.cdc.MustMarshalBinaryBare(att))
+}
+
+func (k Keeper) GetAttestation(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce) *types.Attestation {
+	store := ctx.KVStore(k.storeKey)
+	aKey := types.GetAttestationKey(claimType, nonce)
+	bz := store.Get(aKey)
+	if bz == nil {
+		return nil
+	}
+	var att types.Attestation
+	k.cdc.MustUnmarshalBinaryBare(bz, &att)
+	return &att
+}
+
+func (k Keeper) HasClaim(ctx sdk.Context, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress) bool {
+	store := ctx.KVStore(k.storeKey)
+	return store.Has(types.GetClaimKey(claimType, nonce, validator))
+}
+
+func (k Keeper) IterateClaims(ctx sdk.Context, cb func(key []byte, claimType types.ClaimType, nonce types.Nonce, validator sdk.ValAddress) bool) {
+	prefixStore := prefix.NewStore(ctx.KVStore(k.storeKey), types.OracleClaimKey)
+	iter := prefixStore.Iterator(nil, nil)
+	for ; iter.Valid(); iter.Next() {
+		rawKey := iter.Key()
+		claimType, validator, nonce := types.SplitClaimKey(rawKey)
+		if cb(rawKey, claimType, nonce, validator) {
+			break
+		}
+	}
+}

--- a/module/x/peggy/keeper/test_common.go
+++ b/module/x/peggy/keeper/test_common.go
@@ -57,10 +57,56 @@ func MakeTestCodec() *codec.Codec {
 
 type AlwaysPanicStakingMock struct{}
 
+func (s AlwaysPanicStakingMock) GetLastTotalPower(ctx sdk.Context) (power sdk.Int) {
+	panic("unexpected call")
+}
+
 func (s AlwaysPanicStakingMock) GetBondedValidatorsByPower(ctx sdk.Context) []staking.Validator {
 	panic("unexpected call")
 }
 
 func (s AlwaysPanicStakingMock) GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) int64 {
 	panic("unexpected call")
+}
+
+var _ types.StakingKeeper = &StakingKeeperMock{}
+
+type StakingKeeperMock struct {
+	BondedValidators []staking.Validator
+	ValidatorPower   map[string]int64
+}
+
+func NewStakingKeeperMock(operators ...sdk.ValAddress) *StakingKeeperMock {
+	r := &StakingKeeperMock{
+		BondedValidators: make([]staking.Validator, 0),
+		ValidatorPower:   make(map[string]int64, 0),
+	}
+	const defaultTestPower = 100
+	for _, a := range operators {
+		r.BondedValidators = append(r.BondedValidators, staking.Validator{
+			OperatorAddress: a,
+		})
+		r.ValidatorPower[a.String()] = defaultTestPower
+	}
+	return r
+}
+
+func (s *StakingKeeperMock) GetBondedValidatorsByPower(ctx sdk.Context) []staking.Validator {
+	return s.BondedValidators
+}
+
+func (s *StakingKeeperMock) GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) int64 {
+	v, ok := s.ValidatorPower[operator.String()]
+	if !ok {
+		panic("unknown address")
+	}
+	return v
+}
+
+func (s *StakingKeeperMock) GetLastTotalPower(ctx sdk.Context) (power sdk.Int) {
+	var total int64
+	for _, v := range s.ValidatorPower {
+		total += v
+	}
+	return sdk.NewInt(total)
 }

--- a/module/x/peggy/types/codec.go
+++ b/module/x/peggy/types/codec.go
@@ -19,4 +19,9 @@ func RegisterCodec(cdc *codec.Codec) {
 
 	cdc.RegisterConcrete(Valset{}, "peggy/Valset", nil)
 
+	cdc.RegisterConcrete(MsgCreateEthereumClaims{}, "peggy/MsgCreateEthereumClaims", nil)
+	cdc.RegisterInterface((*EthereumClaim)(nil), nil)
+	cdc.RegisterConcrete(EthereumBridgeDepositClaim{}, "peggy/EthereumBridgeDepositClaim", nil)
+	cdc.RegisterConcrete(EthereumBridgeWithdrawalBatchClaim{}, "peggy/EthereumBridgeWithdrawalBatchClaim", nil)
+	cdc.RegisterConcrete(EthereumBridgeMultiSigUpdateClaim{}, "peggy/EthereumBridgeMultiSigUpdateClaim", nil)
 }

--- a/module/x/peggy/types/errors.go
+++ b/module/x/peggy/types/errors.go
@@ -5,5 +5,8 @@ import (
 )
 
 var (
-	ErrMyCustomError = sdkerrors.Register(ModuleName, 1, "leaving this here as a reference for when we do our errors better")
+	ErrDuplicate    = sdkerrors.Register(ModuleName, 2, "duplicate")
+	ErrInvalidState = sdkerrors.Register(ModuleName, 3, "invalid state")
+	ErrTimeout      = sdkerrors.Register(ModuleName, 4, "timeout")
+	ErrUnknown      = sdkerrors.Register(ModuleName, 5, "unkown")
 )

--- a/module/x/peggy/types/ethereum.go
+++ b/module/x/peggy/types/ethereum.go
@@ -1,0 +1,39 @@
+package types
+
+import (
+	"fmt"
+	"reflect"
+
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+// EthereumAddress defines a standard ethereum address
+type EthereumAddress gethCommon.Address
+
+// NewEthereumAddress is a constructor function for EthereumAddress
+func NewEthereumAddress(address string) EthereumAddress {
+	return EthereumAddress(gethCommon.HexToAddress(address))
+}
+
+// Route should return the name of the module
+func (ethAddr EthereumAddress) String() string {
+	return gethCommon.Address(ethAddr).String()
+}
+
+// MarshalJSON marshals the etherum address to JSON
+func (ethAddr EthereumAddress) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%v\"", ethAddr.String())), nil
+}
+
+// UnmarshalJSON unmarshals an ethereum address
+func (ethAddr *EthereumAddress) UnmarshalJSON(input []byte) error {
+	return hexutil.UnmarshalFixedJSON(reflect.TypeOf(gethCommon.Address{}), input, ethAddr[:])
+}
+
+// ERC20Token unique identifier for an Ethereum erc20 token.
+type ERC20Token struct {
+	Amount               int64           `json:"amount" yaml:"amount"`
+	Symbol               string          `json:"symbol" yaml:"symbol"`
+	TokenContractAddress EthereumAddress `json:"token_contract_address" yaml:"token_contract_address"`
+}

--- a/module/x/peggy/types/expected_keepers.go
+++ b/module/x/peggy/types/expected_keepers.go
@@ -8,4 +8,5 @@ import (
 type StakingKeeper interface {
 	GetBondedValidatorsByPower(ctx sdk.Context) []staking.Validator
 	GetLastValidatorPower(ctx sdk.Context, operator sdk.ValAddress) int64
+	GetLastTotalPower(ctx sdk.Context) (power sdk.Int)
 }

--- a/module/x/peggy/types/key.go
+++ b/module/x/peggy/types/key.go
@@ -21,9 +21,11 @@ const (
 )
 
 var (
-	EthAddressKey    = []byte{0x1}
-	ValsetRequestKey = []byte{0x2}
-	ValsetConfirmKey = []byte{0x3}
+	EthAddressKey        = []byte{0x1}
+	ValsetRequestKey     = []byte{0x2}
+	ValsetConfirmKey     = []byte{0x3}
+	OracleClaimKey       = []byte{0x4}
+	OracleAttestationKey = []byte{0x5}
 )
 
 func GetEthAddressKey(validator sdk.AccAddress) []byte {
@@ -42,4 +44,27 @@ func GetValsetConfirmKey(nonce int64, validator sdk.AccAddress) []byte {
 	binary.BigEndian.PutUint64(nonceBytes, uint64(nonce))
 
 	return append(ValsetConfirmKey, append(nonceBytes, []byte(validator)...)...)
+}
+
+// GetClaimKey creates a key with claim type and address first as they have a fix length.
+// We can use this later for prefix scans to find all claims by type,
+// claims by validator or claims for a nonce
+func GetClaimKey(claimType ClaimType, nonce Nonce, validator sdk.ValAddress) []byte {
+	key := make([]byte, len(OracleClaimKey)+ClaimTypeLen+sdk.AddrLen+len(nonce))
+	copy(key[0:], OracleClaimKey)
+	copy(key[len(OracleClaimKey):], claimType.Bytes())
+	copy(key[len(OracleClaimKey)+ClaimTypeLen:], validator)
+	copy(key[len(OracleClaimKey)+ClaimTypeLen+sdk.AddrLen:], nonce)
+	return key
+}
+func SplitClaimKey(raw []byte) (ClaimType, sdk.ValAddress, Nonce) {
+	return ClaimType(raw[1 : 1+ClaimTypeLen][0]), raw[1+ClaimTypeLen : 1+ClaimTypeLen+sdk.AddrLen], raw[1+ClaimTypeLen+sdk.AddrLen:]
+}
+
+func GetAttestationKey(claimType ClaimType, nonce Nonce) []byte {
+	key := make([]byte, len(OracleAttestationKey)+ClaimTypeLen+len(nonce))
+	copy(key[0:], OracleAttestationKey)
+	copy(key[len(OracleAttestationKey):], claimType.Bytes())
+	copy(key[len(OracleClaimKey)+ClaimTypeLen:], nonce)
+	return key
 }

--- a/module/x/peggy/types/msgs.go
+++ b/module/x/peggy/types/msgs.go
@@ -396,3 +396,127 @@ func (msg MsgEthDeposit) GetSignBytes() []byte {
 func (msg MsgEthDeposit) GetSigners() []sdk.AccAddress {
 	return []sdk.AccAddress{msg.Validator}
 }
+
+type ClaimType byte
+
+const ( // fix size constants
+	ClaimTypeEthereumBridgeDeposit         ClaimType = 0x1
+	ClaimTypeEthereumBridgeWithdrawalBatch ClaimType = 0x2
+	ClaimTypeEthereumBridgeMultiSigUpdate  ClaimType = 0x3
+)
+const ClaimTypeLen = 1
+
+func (c ClaimType) Bytes() []byte {
+	return []byte{byte(c)}
+}
+
+type EthereumClaim interface {
+	GetNonce() Nonce
+	GetType() ClaimType
+	ValidateBasic() error
+}
+
+var (
+	_ EthereumClaim = EthereumBridgeDepositClaim{}
+	_ EthereumClaim = EthereumBridgeWithdrawalBatchClaim{}
+	_ EthereumClaim = EthereumBridgeMultiSigUpdateClaim{}
+)
+
+type EthereumBridgeDepositClaim struct {
+	Nonce          []byte `json:"nonce" yaml:"nonce"`
+	ERC20Token     ERC20Token
+	EthereumSender EthereumAddress `json:"ethereum_sender" yaml:"ethereum_sender"`
+	CosmosReceiver sdk.AccAddress  `json:"cosmos_receiver" yaml:"cosmos_receiver"`
+}
+
+func (e EthereumBridgeDepositClaim) GetType() ClaimType {
+	return ClaimTypeEthereumBridgeDeposit
+}
+
+func (e EthereumBridgeDepositClaim) GetNonce() Nonce {
+	return e.Nonce
+}
+
+func (e EthereumBridgeDepositClaim) ValidateBasic() error {
+	// todo: implement me
+	return nil
+}
+
+// todo: This is not needed with the batch withdrawal
+//type EthereumBridgeWithdrawalClaim struct {
+//	Nonce            int `json:"nonce" yaml:"nonce"`
+//	ERC20Token       ERC20Token
+//	EthereumReceiver EthereumAddress
+//	CosmosSender     sdk.AccAddress
+//}
+
+type EthereumBridgeWithdrawalBatchClaim struct {
+	Nonce []byte `json:"nonce" yaml:"nonce"`
+}
+
+func (e EthereumBridgeWithdrawalBatchClaim) GetType() ClaimType {
+	return ClaimTypeEthereumBridgeWithdrawalBatch
+}
+
+func (e EthereumBridgeWithdrawalBatchClaim) GetNonce() Nonce {
+	return e.Nonce
+}
+
+func (e EthereumBridgeWithdrawalBatchClaim) ValidateBasic() error {
+	// todo: implement me
+	return nil
+}
+
+type EthereumBridgeMultiSigUpdateClaim struct {
+	Nonce []byte `json:"nonce" yaml:"nonce"`
+}
+
+func (e EthereumBridgeMultiSigUpdateClaim) GetType() ClaimType {
+	return ClaimTypeEthereumBridgeMultiSigUpdate
+}
+
+func (e EthereumBridgeMultiSigUpdateClaim) GetNonce() Nonce {
+	return e.Nonce
+}
+
+func (e EthereumBridgeMultiSigUpdateClaim) ValidateBasic() error {
+	// todo: implement me
+	return nil
+}
+
+const (
+	TypeMsgCreateEthereumClaims = "create_eth_claims"
+)
+
+var (
+	_ sdk.Msg = &MsgCreateEthereumClaims{}
+)
+
+type MsgCreateEthereumClaims struct {
+	EthereumChainID       string // todo: revisit type. can be int/ string/ ?
+	BridgeContractAddress EthereumAddress
+	Orchestrator          sdk.AccAddress
+	Claims                []EthereumClaim
+}
+
+func (m MsgCreateEthereumClaims) Route() string {
+	return RouterKey
+}
+
+func (m MsgCreateEthereumClaims) Type() string {
+	return TypeMsgCreateEthereumClaims
+}
+
+func (m MsgCreateEthereumClaims) ValidateBasic() error {
+	// todo: implement proper
+	return nil
+}
+
+func (m MsgCreateEthereumClaims) GetSignBytes() []byte {
+	bz := ModuleCdc.MustMarshalJSON(m)
+	return sdk.MustSortJSON(bz)
+}
+
+func (m MsgCreateEthereumClaims) GetSigners() []sdk.AccAddress {
+	return []sdk.AccAddress{m.Orchestrator}
+}

--- a/module/x/peggy/types/oracle.go
+++ b/module/x/peggy/types/oracle.go
@@ -1,0 +1,100 @@
+package types
+
+import (
+	"fmt"
+	"math/big"
+	"time"
+
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+type Nonce []byte
+
+type AttestationCertainty uint8
+
+const (
+	CertaintyUnknown   AttestationCertainty = 0
+	CertaintyRequested AttestationCertainty = 1
+	CertaintyObserved  AttestationCertainty = 2
+)
+
+type AttestationProcessStatus uint8
+
+const (
+	ProcessStatusUnknown   AttestationProcessStatus = 0
+	ProcessStatusInit      AttestationProcessStatus = 1
+	ProcessStatusProcessed AttestationProcessStatus = 2 // prevent double processing
+	//ProcessStatusTimeout   AttestationProcessStatus = 3 // who sets it if we return errors?
+)
+
+type AttestationProcessResult uint8
+
+const (
+	ProcessResultUnknown AttestationProcessResult = 0
+	ProcessResultSuccess AttestationProcessResult = 1
+	ProcessResultFailure AttestationProcessResult = 2
+)
+
+type Attestation struct {
+	ClaimType           ClaimType
+	Nonce               Nonce // or bytes or int?
+	Certainty           AttestationCertainty
+	Status              AttestationProcessStatus
+	ProcessResult       AttestationProcessResult
+	Tally               AttestationTally
+	SubmitTime          time.Time
+	ConfirmationEndTime time.Time // votes collected <= end time. should be < unbonding period
+	// ExpiryTime time.Time // todo: do we want to keep Attestations forever persisted or can we delete them?
+}
+
+type AttestationTally struct {
+	TotalVotesPower    uint64 // can this overflow?
+	TotalVotesCount    uint64
+	RequiredVotesPower uint64 // todo: revisit if the assumption is true that we can use the values from first claim timestamp
+	RequiredVotesCount uint64 // todo: revisit
+}
+
+func (t *AttestationTally) addVote(power uint64) {
+	t.TotalVotesCount += 1
+	t.TotalVotesPower += power
+}
+
+func (t AttestationTally) thresholdsReached() bool {
+	return t.TotalVotesPower > t.RequiredVotesPower &&
+		t.TotalVotesCount > t.RequiredVotesCount
+}
+
+func (a *Attestation) AddConfirmation(now time.Time, power uint64) error {
+	if a.Status != ProcessStatusInit {
+		return sdkerrors.Wrapf(ErrInvalidState, "%d", a.Status) // no status to string impl, yet
+	}
+	if now.After(a.ConfirmationEndTime) {
+		return ErrTimeout
+	}
+	a.Tally.addVote(power)
+	if a.Tally.thresholdsReached() {
+		a.Certainty = CertaintyObserved
+	}
+	return nil
+}
+
+// The Fraction type represents a numerator and denominator to enable higher precision thresholds in
+// the election rules. For example:
+// numerator: 1, denominator: 2 => > 50%
+// numerator: 2, denominator: 3 => > 66.666..%
+// numerator: 6273, denominator: 10000 => > 62.73%
+// Valid range of the fraction is 0.5 to 1.
+type Fraction struct {
+	// The top number in a fraction.
+	Numerator uint32
+	// The bottom number
+	Denominator uint32
+}
+
+// mul multiply
+func (f Fraction) Mul(factor uint64) uint64 {
+	a := new(big.Int).Mul(big.NewInt(int64(factor)), big.NewInt(int64(f.Numerator)))
+	r := new(big.Int).Div(a, big.NewInt(int64(f.Denominator)))
+	fmt.Printf("%d *%d / %d = %d \n", f.Numerator, factor, f.Denominator, r.Uint64())
+	return r.Uint64() // this is where rounding happens
+}

--- a/module/x/peggy/types/params.go
+++ b/module/x/peggy/types/params.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cosmos/cosmos-sdk/x/params"
 	"github.com/cosmos/cosmos-sdk/x/params/subspace"
@@ -11,6 +12,17 @@ import (
 
 // DefaultParamspace defines the default auth module parameter subspace
 const DefaultParamspace = ModuleName
+
+// todo: implement oracle constants as params
+
+const AttestationPeriod = 24 * time.Hour // TODO: value????
+// voting: threshold >2/3 of validator power AND > 1/2 of validator count?
+var (
+	AttestationVotesCountThreshold = Fraction{1, 2}
+	AttestationVotesPowerThreshold = Fraction{2, 3}
+	BridgeContractAddress          = NewEthereumAddress("")
+	BridgeContractChainID          = "0" // todo: revisit
+)
 
 // TODO: Defaults don't make sense for any of our params. Should we still have them?
 

--- a/readme.md
+++ b/readme.md
@@ -1,83 +1,8 @@
-# Althea Peggy
+# Althea Peggy FORK
 
-Althea Peggy is a simplified vision of a Cosmos <-> Ethereum 'peg zone' focused on maximum design simplicity and efficiency.
+This repo is based on the Althea Peggy and contains my design spikes and examples.
 
-For now Althea Peggy is focused on only one of the major functions of an Ethereum peg zone. Bidirectional transfer of ERC20 assets originating on Ethereum to a Cosmos based chain.
+## License
+This is not production ready code! Do not use without my permission.
 
-An expansion of this feature set is expected, but will only be performed once basic transfers are in production. This gives us the opportunity to develop solid foundations and technology useful for the larger peg zone vision without getting bogged down by a larger feature surface.
-
-## Design simplifications from the larger peg zone vision
-
-- Validators are fully trusted to manage the bridge. Validator powers and votes are replicated on the Ethereum side so trust in bridge assets depends entirely on trust in the validator set of the peg zone chain. This has known problems where the assets in the bridge exceed the market cap of the native token. We accept these known issues in exchange for the dramatic design simplification combined with acceptable decentralization this design provides.
-- The Althea Peggy Ethereum contract only supports ERC20 transfers and not arbitrary data. This helps keep the contract simple enough to optimize heavily and reach production quality quickly.
-- The Relayer as a discrete binary only exists to facilitate the bridge fee market. All chain oracle functions will be integrated directly into the Gaiad binary. This makes it mandatory for peg zone validators to maintain a trusted Ethereum node and removes all trust and game theory implications that usually arise from independent relayers.
-
-## Key Components you can run today
-
-- A highly efficient way of mirroring Cosmos validator voting onto Ethereum. The Althea-Peggy solidity contract has validator set updates costing ~500,000 gas ($2 @ 20gwei) and transaction batches have a base cost of ~500,000 gas ($2 @ 20gwei). This is tested using a snapshot of the Cosmos Hub validator set, with 100+ unique validators. We hope to further reduce these gas costs, see `solidity/possible_optimizations.md` for more details. Batches may contain arbitrary numbers of transactions within the limits of ERC20 sends per block. Allowing for costs to be heavily amortized on high volume bridges. This code will likely be re-used in any iteration of Peggy.
-- All up integration tests, we provide a one button integration test that deploys a full arbitrary validator Cosmos chain and testnet Geth chain for both development and integration test validation. We believe having a in depth test environment reflecting the full deployment and production-like use of the code is essential to productive development.
-
-## Running the all up tests
-
-These tests cover everything that's working in this repo (or not) currently they build the Ethereum contract, run the happy path tests and then build + deploy a small Cosmos blockchain in docker running the code in the `module` folder. This code doesn't do much at the moment as we're working on getting it to generate validator updates to relay to the Ethereum contract.
-
-To run the test simply have docker installed and run.
-
-`bash tests/all-up-test.sh`
-
-# Developer guide
-
-## Solidity Contract
-
-in the `solidity` folder
-
-Run `HUSKY_SKIP_INSTALL=1 npm install`, then `npm run typechain`.
-
-Run `npm run evm` in a separate terminal and then
-
-Run `npm run test` to run tests.
-
-After modifying solidity files, run `npm run typechain` to recompile contract
-typedefs.
-
-The Solidity contract is also covered in the Cosmos module tests, where it will be automatically deployed to the Geth test chain inside the development container for a micro testnet every integration test run.
-
-## Cosmos Module
-
-We provide a standard container-based development environment that automatically bootstraps a Cosmos chain and Ethereum chain for testing. We believe standardization of the development environment and ease of development are essential so please file issues if you run into issues with the development flow.
-
-### To test your changes quickly
-
-This method is dictinct from the all up test described above. Although it runs the same components it's much faster when editing individual components.
-
-1. run `./tests/build-container.sh`
-2. run `./tests/start-chains.sh`
-3. switch to a new terminal and run `./tests/run-tests.sh`
-4. Or, `docker exec -it peggy_test_instance /bin/bash` should allow you to access a shell inside the test container
-
-Change the code, and when you want to test it again, restart `./tests/start-chains.sh` and run `./tests/run-tests.sh`.
-
-### Explanation:
-
-`./tests/build-container.sh` builds the base container and builds the peggy test zone for the first time. This results in a Docker container which contains cached Go dependencies (the base container).
-
-`./tests/start-chains.sh` starts a test container based on the base container and copies the current source code (including any changes you have made) into it. It then builds the peggy test zone, benefiting from the cached Go dependencies. It then starts the Cosmos chain running on your new code. It also starts an Ethereum node. These nodes stay running in the terminal you started it in, and it can be useful to look at the logs. Be aware that this also mounts the peggy folder into the container, meaning changes you make will be reflected there.
-
-`./tests/run-tests.sh` connects to the running test container and runs the integration test found in `./tests/integration-tests.sh`
-
-### Tips for IDEs:
-
-- Launch VS Code in /solidity with the solidity extension enabled to get inline typechecking of the solidity contract
-- Launch VS Code in /module/app with the go extension enabled to get inline typechecking of the dummy cosmos chain
-
-### Working inside the container
-
-It can be useful to modify, recompile, and restart the testnet without restarting the container, for example if you are running a text editor in the container and would not like it to exit, or if you are editing dependencies stored in the container's `/go/` folder.
-
-In this workflow, you can use `./tests/reload-code.sh` to recompile and restart the testnet without restarting the container.
-
-For example, you can use VS Code's "Remote-Container" extension to attach to the running container started with `./tests/start-chains.sh`, then edit the code inside the container, restart the testnet with `./tests/reload-code.sh`, and run the tests with `./tests/integration-tests.sh`.
-
-## Debugger
-
-To use a stepping debugger in VS Code, follow the "Working inside the container" instructions above, but set up a one node testnet using `./tests/reload-code.sh 1`. Now kill the node with `pkill peggyd`. Start the debugger from within VS Code, and you will have a 1 node debuggable testnet.
+Copyright (c) by Alexander Peters 2020


### PR DESCRIPTION
🚨  Design show case NOT for production

Assumptions
- An orchestrator may want to submit multiple claims with a msg (withdrawal batch update + MultiSig Set update )
- Nonces are not unique without a context (withdrawal nonce and MultiSig Set update can have same nonce (=height))
- A nonce is unique in it's context and never reused
- Multiple claims by an orchestrator for the same ETH event are forbidden
- We know the ETH event types beforehand (and whitelist them as ClaimTypes) **A string would work as well but may require  second index(es)**
- For an **observation** status in Attestation the power AND count thresholds must be exceeded
- Fraction type allows higher precision math than %. For example with 2/3

A good start to follow the process would be the `x/peggy/handler_test.go` file